### PR TITLE
Fix ReferenceError from missing findAddrInput helper

### DIFF
--- a/browser-navi/js/ui/_index.js
+++ b/browser-navi/js/ui/_index.js
@@ -5,6 +5,15 @@ import { setupSettings } from './settings-panel.js';
 import { setupStartStop } from './startstop.js';
 import { createHUD } from './hud.js';
 
+function findAddrInput() {
+  return (
+    document.getElementById('addr') ||
+    document.getElementById('search') ||
+    document.querySelector('#search-input, [data-addr-input], input[name="addr"]') ||
+    null
+  );
+}
+
 export function bindUI(mapCtrl, navCtrl){
   const els = {
     addr:            findAddrInput(),


### PR DESCRIPTION
## Summary
- add a local helper to locate the address input so bindUI can initialize correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39a4a5f188331af55d532f8a8e84b